### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,12 @@ Biome's linter will catch most issues automatically. Focus your attention on:
 ---
 
 Most formatting and common issues are automatically fixed by Biome. Run `bun x ultracite fix` before committing to ensure compliance.
+
+## Cursor Cloud specific instructions
+
+This is a **Next.js 16 (Turbopack) + React 19** personal website/blog managed with **Bun** (see `bun.lock`). There is a single service.
+
+- Run the dev server with `bun run dev` (Next.js on `http://localhost:3000`). Lint with `bun run lint` (Biome); build with `bun run build`. There is no automated test suite.
+- Dependency install: use `bun install --ignore-scripts`. A plain `bun install` fails in this environment because the `prepare` script runs `lefthook install`, which aborts when `core.hooksPath` is set (Cursor manages git hooks). `--ignore-scripts` only skips that git-hook setup and does not affect app dependencies. The update script already handles this on startup.
+- All PostHog env vars in `.env.example` are optional; without them the server logs a harmless `[posthog-logs] ... disabled ... token is missing` warning and runs normally.
+- Blog posts (`content/blog/*.mdx`) support content negotiation: requesting a post with `Accept: text/markdown` returns raw markdown via `app/api/blog/[slug]/raw` (see `proxy.ts`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js + Bun personal website and documents non-obvious startup caveats for future Cloud agents.

- Installs Bun (package manager per `bun.lock`) and dependencies via `bun install --ignore-scripts`.
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the single Next.js service, run/lint/build commands, the `lefthook`/`core.hooksPath` install caveat, optional PostHog env vars, and the blog markdown content-negotiation feature.

## Why `--ignore-scripts`

A plain `bun install` fails here because the `prepare` script runs `lefthook install`, which aborts when `core.hooksPath` is set (Cursor manages git hooks). `--ignore-scripts` skips only that git-hook setup; app dependencies install normally.

## Verification

- `bun run lint` (Biome) passes.
- `bun run dev` serves on `http://localhost:3000`; homepage, `/blog`, blog post pages, and the `Accept: text/markdown` raw-markdown API all return 200 and render correctly.

[nextjs_site_walkthrough.mp4](https://cursor.com/agents/bc-904846fd-5d22-4e68-b1cc-61a4824cbdcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_site_walkthrough.mp4)

Homepage and blog post rendering:

[Homepage](https://cursor.com/agents/bc-904846fd-5d22-4e68-b1cc-61a4824cbdcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[The Intent Layer blog post](https://cursor.com/agents/bc-904846fd-5d22-4e68-b1cc-61a4824cbdcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904846fd-5d22-4e68-b1cc-61a4824cbdcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904846fd-5d22-4e68-b1cc-61a4824cbdcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

